### PR TITLE
Overriding the scope separator

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -16,6 +16,11 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
+    protected $scopeSeparator = ' ';
+    
+    /**
+     * {@inheritdoc}
+     */
     protected $scopes = ['public'];
 
     /**


### PR DESCRIPTION
Overriding the scope separator from Socialite because default comma one causes an issue with authorization when more scopes are defined because Dribbble requires space separator and not comma in requests.